### PR TITLE
Fix/names handling

### DIFF
--- a/R/calendar.R
+++ b/R/calendar.R
@@ -517,7 +517,12 @@ as_year_quarter_day.clock_calendar <- function(x, ..., start = 1L) {
 # ------------------------------------------------------------------------------
 
 field_year <- function(x) {
-  field(x, "year")
+  # The `year` field is the first field of every calendar type, which makes
+  # it the field that names are on. When extracting the field, we don't ever
+  # want the names to come with it.
+  out <- field(x, "year")
+  names(out) <- NULL
+  out
 }
 field_quarter <- function(x) {
   field(x, "quarter")

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -336,6 +336,14 @@ clock_rcrd_proxy <- function(x) {
   .Call("_clock_clock_rcrd_proxy", x, PACKAGE = "clock")
 }
 
+clock_rcrd_names <- function(x) {
+  .Call("_clock_clock_rcrd_names", x, PACKAGE = "clock")
+}
+
+clock_rcrd_set_names <- function(x, names) {
+  .Call("_clock_clock_rcrd_set_names", x, names, PACKAGE = "clock")
+}
+
 sys_now_cpp <- function() {
   .Call("_clock_sys_now_cpp", PACKAGE = "clock")
 }

--- a/R/duration.R
+++ b/R/duration.R
@@ -501,7 +501,13 @@ duration_precision <- function(x) {
 # ------------------------------------------------------------------------------
 
 field_ticks <- function(x) {
-  field(x, "ticks")
+  # The `ticks` field is the first field of every
+  # duration / time point / zoned time type, which makes it the field that
+  # names are on. When extracting the field, we don't ever
+  # want the names to come with it.
+  out <- field(x, "ticks")
+  names(out) <- NULL
+  out
 }
 field_ticks_of_day <- function(x) {
   field(x, "ticks_of_day")

--- a/R/rcrd.R
+++ b/R/rcrd.R
@@ -1,71 +1,13 @@
 # ------------------------------------------------------------------------------
 
-clock_rcrd_names <- function(x) {
-  attr(x, "clock_rcrd:::names", exact = TRUE)
-}
-
-clock_rcrd_set_names <- function(x, value) {
-  attrib <- attributes(x)
-
-  # Remove names
-  if (is.null(value)) {
-    attrib[["clock_rcrd:::names"]] <- NULL
-    attributes(x) <- attrib
-
-    return(x)
-  }
-
-  size <- vec_size(x)
-  value <- as_names(value, size)
-
-  attrib[["clock_rcrd:::names"]] <- value
-  attributes(x) <- attrib
-
-  x
-}
-
-as_names <- function(x, size) {
-  x <- unstructure(x)
-
-  if (!is_character(x)) {
-    x <- as.character(x)
-  }
-
-  validate_names(x, size)
-
-  x
-}
-
-validate_names <- function(names, size) {
-  if (is_null(names)) {
-    return(invisible(names))
-  }
-
-  if (!is_character(names)) {
-    abort("Names must be a character vector.")
-  }
-
-  if (length(names) != size) {
-    abort(paste0("Names must have length ", size, " not ", length(names), "."))
-  }
-
-  if (any(is.na(names))) {
-    abort("Names cannot be `NA`.")
-  }
-
-  invisible(names)
-}
-
-# ------------------------------------------------------------------------------
-
 #' @export
 names.clock_rcrd <- function(x) {
-  attr(x, "clock_rcrd:::names", exact = TRUE)
+  .Call("_clock_clock_rcrd_names", x, PACKAGE = "clock")
 }
 
 #' @export
 `names<-.clock_rcrd` <- function(x, value) {
-  clock_rcrd_set_names(x, value)
+  .Call("_clock_clock_rcrd_set_names", x, value, PACKAGE = "clock")
 }
 
 # ------------------------------------------------------------------------------

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -14,8 +14,12 @@ time_point_precision <- function(x) {
   attr(x, "precision", exact = TRUE)
 }
 
-time_point_duration <- function(x) {
-  names <- NULL
+time_point_duration <- function(x, retain_names = FALSE) {
+  if (retain_names) {
+    names <- clock_rcrd_names(x)
+  } else {
+    names <- NULL
+  }
   precision <- time_point_precision(x)
   new_duration_from_fields(x, precision, names)
 }
@@ -457,9 +461,7 @@ time_point_minus_time_point <- function(x, y, names) {
 
 #' @export
 as_duration.clock_time_point <- function(x) {
-  out <- time_point_duration(x)
-  out <- clock_rcrd_set_names(out, clock_rcrd_names(x))
-  out
+  time_point_duration(x, retain_names = TRUE)
 }
 
 #' @export

--- a/R/zoned-time.R
+++ b/R/zoned-time.R
@@ -17,19 +17,6 @@ zoned_time_precision <- function(x) {
   attr(x, "precision", exact = TRUE)
 }
 
-zoned_time_sys_time <- function(x) {
-  names <- NULL
-  precision <- zoned_time_precision(x)
-  new_sys_time_from_fields(x, precision, names)
-}
-zoned_time_naive_time <- function(x) {
-  names <- NULL
-  zone <- zoned_time_zone(x)
-  precision <- zoned_time_precision(x)
-  fields <- get_naive_time_cpp(x, precision, zone)
-  new_naive_time_from_fields(fields, precision, names)
-}
-
 # ------------------------------------------------------------------------------
 
 #' @export
@@ -255,16 +242,18 @@ as_zoned_time.clock_zoned_time <- function(x, ...) {
 
 #' @export
 as_sys_time.clock_zoned_time <- function(x) {
-  out <- zoned_time_sys_time(x)
-  out <- clock_rcrd_set_names(out, clock_rcrd_names(x))
-  out
+  names <- clock_rcrd_names(x)
+  precision <- zoned_time_precision(x)
+  new_sys_time_from_fields(x, precision, names)
 }
 
 #' @export
 as_naive_time.clock_zoned_time <- function(x) {
-  out <- zoned_time_naive_time(x)
-  out <- clock_rcrd_set_names(out, clock_rcrd_names(x))
-  out
+  names <- clock_rcrd_names(x)
+  zone <- zoned_time_zone(x)
+  precision <- zoned_time_precision(x)
+  fields <- get_naive_time_cpp(x, precision, zone)
+  new_naive_time_from_fields(fields, precision, names)
 }
 
 # ------------------------------------------------------------------------------

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -597,6 +597,20 @@ extern "C" SEXP _clock_clock_rcrd_proxy(SEXP x) {
     return cpp11::as_sexp(clock_rcrd_proxy(cpp11::as_cpp<cpp11::decay_t<SEXP>>(x)));
   END_CPP11
 }
+// rcrd.cpp
+SEXP clock_rcrd_names(SEXP x);
+extern "C" SEXP _clock_clock_rcrd_names(SEXP x) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(clock_rcrd_names(cpp11::as_cpp<cpp11::decay_t<SEXP>>(x)));
+  END_CPP11
+}
+// rcrd.cpp
+SEXP clock_rcrd_set_names(SEXP x, SEXP names);
+extern "C" SEXP _clock_clock_rcrd_set_names(SEXP x, SEXP names) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(clock_rcrd_set_names(cpp11::as_cpp<cpp11::decay_t<SEXP>>(x), cpp11::as_cpp<cpp11::decay_t<SEXP>>(names)));
+  END_CPP11
+}
 // sys-time.cpp
 cpp11::writable::list sys_now_cpp();
 extern "C" SEXP _clock_sys_now_cpp() {
@@ -750,7 +764,9 @@ extern SEXP _clock_as_year_month_weekday_from_sys_time_cpp(SEXP, SEXP);
 extern SEXP _clock_as_year_quarter_day_from_sys_time_cpp(SEXP, SEXP, SEXP);
 extern SEXP _clock_as_zoned_sys_time_from_naive_time_cpp(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _clock_clock_init_utils();
+extern SEXP _clock_clock_rcrd_names(SEXP);
 extern SEXP _clock_clock_rcrd_proxy(SEXP);
+extern SEXP _clock_clock_rcrd_set_names(SEXP, SEXP);
 extern SEXP _clock_clock_set_install(SEXP);
 extern SEXP _clock_clock_to_string(SEXP);
 extern SEXP _clock_collect_iso_year_week_day_fields(SEXP, SEXP);
@@ -856,7 +872,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_clock_as_year_quarter_day_from_sys_time_cpp",           (DL_FUNC) &_clock_as_year_quarter_day_from_sys_time_cpp,            3},
     {"_clock_as_zoned_sys_time_from_naive_time_cpp",           (DL_FUNC) &_clock_as_zoned_sys_time_from_naive_time_cpp,            5},
     {"_clock_clock_init_utils",                                (DL_FUNC) &_clock_clock_init_utils,                                 0},
+    {"_clock_clock_rcrd_names",                                (DL_FUNC) &_clock_clock_rcrd_names,                                 1},
     {"_clock_clock_rcrd_proxy",                                (DL_FUNC) &_clock_clock_rcrd_proxy,                                 1},
+    {"_clock_clock_rcrd_set_names",                            (DL_FUNC) &_clock_clock_rcrd_set_names,                             2},
     {"_clock_clock_set_install",                               (DL_FUNC) &_clock_clock_set_install,                                1},
     {"_clock_clock_to_string",                                 (DL_FUNC) &_clock_clock_to_string,                                  1},
     {"_clock_collect_iso_year_week_day_fields",                (DL_FUNC) &_clock_collect_iso_year_week_day_fields,                 2},

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -16,13 +16,12 @@ SEXP strings_clock_year_month_weekday = NULL;
 SEXP strings_clock_iso_year_week_day = NULL;
 SEXP strings_clock_year_quarter_day = NULL;
 SEXP strings_data_frame = NULL;
-SEXP strings_clock_rcrd_names = NULL;
 
 SEXP syms_precision = NULL;
 SEXP syms_start = NULL;
 SEXP syms_clock = NULL;
 SEXP syms_zone = NULL;
-SEXP syms_clock_rcrd_names = NULL;
+SEXP syms_set_names = NULL;
 
 SEXP classes_duration = NULL;
 SEXP classes_sys_time = NULL;
@@ -39,7 +38,7 @@ SEXP ints_empty = NULL;
 [[cpp11::register]]
 SEXP
 clock_init_utils() {
-  strings = Rf_allocVector(STRSXP, 16);
+  strings = Rf_allocVector(STRSXP, 15);
   R_PreserveObject(strings);
   MARK_NOT_MUTABLE(strings);
 
@@ -88,15 +87,12 @@ clock_init_utils() {
   strings_data_frame = Rf_mkChar("data.frame");
   SET_STRING_ELT(strings, 14, strings_data_frame);
 
-  strings_clock_rcrd_names = Rf_mkChar("clock_rcrd:::names");
-  SET_STRING_ELT(strings, 15, strings_clock_rcrd_names);
-
 
   syms_precision = Rf_install("precision");
   syms_start = Rf_install("start");
   syms_clock = Rf_install("clock");
   syms_zone = Rf_install("zone");
-  syms_clock_rcrd_names = Rf_install("clock_rcrd:::names");
+  syms_set_names = Rf_install("names<-");
 
 
   classes_duration = Rf_allocVector(STRSXP, 4);

--- a/src/utils.h
+++ b/src/utils.h
@@ -10,13 +10,12 @@
 // -----------------------------------------------------------------------------
 
 extern SEXP strings_empty;
-extern SEXP strings_clock_rcrd_names;
 
 extern SEXP syms_precision;
 extern SEXP syms_start;
 extern SEXP syms_clock;
 extern SEXP syms_zone;
-extern SEXP syms_clock_rcrd_names;
+extern SEXP syms_set_names;
 
 extern SEXP classes_duration;
 extern SEXP classes_sys_time;
@@ -135,6 +134,21 @@ void
 r_init_data_frame(SEXP x, r_ssize n_rows) {
   init_compact_rownames(x, n_rows);
   Rf_setAttrib(x, R_ClassSymbol, classes_data_frame);
+}
+
+// -----------------------------------------------------------------------------
+
+/*
+ * `names<-()` can take advantage of shallow duplication using an ALTREP wrapper
+ * which is otherwise not exposed in the R API
+ */
+static
+inline
+SEXP set_names_dispatch(SEXP x, SEXP value) {
+  SEXP call = PROTECT(Rf_lang3(syms_set_names, x, value));
+  SEXP out = Rf_eval(call, R_GlobalEnv);
+  UNPROTECT(1);
+  return out;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/utils.h
+++ b/src/utils.h
@@ -64,49 +64,6 @@ r_list_deref_const(SEXP x) {
 
 static
 inline
-bool
-r_chr_any_na(const SEXP* p_x, r_ssize size) {
-  for (r_ssize i = 0; i < size; ++i) {
-    if (p_x[i] == r_chr_na) {
-      return true;
-    }
-  }
-  return false;
-}
-
-static
-inline
-SEXP
-r_repair_na_names(SEXP names) {
-  const SEXP* p_names = r_chr_deref_const(names);
-  const r_ssize size = Rf_xlength(names);
-
-  bool any_na = r_chr_any_na(p_names, size);
-
-  if (!any_na) {
-    return names;
-  }
-
-  SEXP out = PROTECT(Rf_allocVector(STRSXP, size));
-
-  for (r_ssize i = 0; i < size; ++i) {
-    const SEXP name = p_names[i];
-
-    if (name == r_chr_na) {
-      SET_STRING_ELT(out, i, strings_empty);
-    } else {
-      SET_STRING_ELT(out, i, name);
-    }
-  }
-
-  UNPROTECT(1);
-  return out;
-}
-
-// -----------------------------------------------------------------------------
-
-static
-inline
 SEXP new_compact_rownames(r_ssize n_rows) {
   if (n_rows <= 0) {
     return ints_empty;


### PR DESCRIPTION
Closes #74 

It ended up being best to put the names directly on the first rcrd field. This ensures that proxy/restore really only have to create a new data frame. The names get sliced alongside the first field. vctrs primatives all seem to ignore names attributes on data frame columns when determining things like equality or hash values.

This also fixed that original problem in #74, since now the number of columns in the ptype proxy doesn't vary based on whether or not there are names 

``` r
library(clock)
library(vctrs)
#> Warning: package 'vctrs' was built under R version 4.0.2

x <- c(foo = year_month_day(2019, 01))

# 2 columns, names are stored in `year`
vec_proxy(x)
#>   year month
#> 1 2019     1

vec_proxy(x)$year
#>  foo 
#> 2019

# 2 columns
ptype <- year_month_day(integer(), integer())
vec_proxy(ptype)
#> [1] year  month
#> <0 rows> (or 0-length row.names)

# All better!
vec_c(x, .ptype = x)
#> <year_month_day<month>[invalid=0][1]>
#>       foo 
#> "2019-01"
vec_c(x, .ptype = ptype)
#> <year_month_day<month>[invalid=0][1]>
#>       foo 
#> "2019-01"
```

<sup>Created on 2021-01-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>