### PR TITLE
Separate durations into calendrical and chronological

### DIFF
--- a/R/duration.R
+++ b/R/duration.R
@@ -2,7 +2,30 @@
 #'
 #' @description
 #' These helpers construct durations of the specified precision. Durations
-#' represent units of time in a specified precision.
+#' represent units of time.
+#'
+#' Durations are separated into two categories:
+#'
+#' **Calendrical**
+#'
+#' - year
+#' - quarter
+#' - month
+#'
+#' **Chronological**
+#'
+#' - week
+#' - day
+#' - hour
+#' - minute
+#' - second
+#' - millisecond
+#' - microsecond
+#' - nanosecond
+#'
+#' Calendrical durations are generally used when manipulating calendar types,
+#' like year-month-day. Chronological durations are generally used when
+#' working with time points, like sys-time or naive-time.
 #'
 #' @section Internal Representation:
 #'
@@ -40,6 +63,13 @@
 #' A duration of 1 quarter is defined as exactly 1/4 of a year.
 #'
 #' A duration of 1 week is defined as exactly 7 days.
+#'
+#' These conversions come into play when doing operations like adding or
+#' flooring durations. Generally, you add two calendrical durations together
+#' to get a new calendrical duration, rather than adding a calendrical and
+#' a chronological duration together. The one exception is [duration_cast()],
+#' which can cast durations to any other precision, with a potential loss of
+#' information.
 #'
 #' @param n `[integer]`
 #'

--- a/R/duration.R
+++ b/R/duration.R
@@ -849,17 +849,11 @@ vec_arith.numeric.clock_duration <- function(op, x, y, ...) {
 #' _more precise precision_ of the two durations.
 #'
 #' @details
-#' Duration arithmetic is most useful when adding sub-daily or daily
-#' precisions together, or when adding monthly/quarterly/yearly precisions to
-#' other durations of similar precisions.
-#'
-#' Be _extremely_ careful when adding sub-daily or daily precisions to less
-#' precise precisions, such as monthly or yearly. Durations are defined in terms
-#' of a number of seconds, and calendrical months and years cannot be broken
-#' down like that, since they are irregular periods of time (there aren't always
-#' 30 days in a month, or 365 days in a year). Read the Internal Representation
-#' section of the documentation for [duration helpers][duration-helper] to
-#' learn more about how durations are defined.
+#' You can add calendrical durations to other calendrical durations,
+#' and chronological durations to other chronological durations, but you can't
+#' add a chronological duration to a calendrical duration
+#' (such as adding days and months). For more information, see the
+#' documentation on the [duration helper][duration-helper] page.
 #'
 #' `x` and `n` are recycled against each other.
 #'
@@ -887,6 +881,10 @@ vec_arith.numeric.clock_duration <- function(op, x, y, ...) {
 #' # precision of the two back, which is seconds
 #' y <- duration_days(1)
 #' add_seconds(y, 5)
+#'
+#' # But you can't add a chronological duration (days) and
+#' # a calendrical duration (months)
+#' try(add_months(y, 1))
 #'
 #' # You can add years to a duration of months, which adds
 #' # an additional 12 months / year

--- a/R/duration.R
+++ b/R/duration.R
@@ -437,11 +437,11 @@ duration_cast <- function(x, precision) {
 #'   rounding up on ties.
 #'
 #' @details
-#' Durations can be separated into two groups for rounding purposes. You can
-#' round within these groups, but not across these groups:
-#'
-#' - year, quarter, month
-#' - week, day, hour, minute, second, millisecond, microsecond, nanosecond
+#' You can floor calendrical durations to other calendrical durations, and
+#' chronological durations to other chronological durations, but you can't
+#' floor a chronological duration to a calendrical duration (such as flooring
+#' from day to month). For more information, see the documentation on the
+#' [duration helper][duration-helper] page.
 #'
 #' @inheritParams ellipsis::dots_empty
 #' @inheritParams duration_cast
@@ -450,6 +450,8 @@ duration_cast <- function(x, precision) {
 #'
 #'   A positive integer specifying the multiple of `precision` to use.
 #'
+#' @return `x` rounded to the `precision`.
+#'
 #' @name duration-rounding
 #'
 #' @examples
@@ -457,6 +459,10 @@ duration_cast <- function(x, precision) {
 #'
 #' duration_floor(x, "day")
 #' duration_ceiling(x, "day")
+#'
+#' # Can't floor from a chronological duration (seconds)
+#' # to a calendrical duration (months)
+#' try(duration_floor(x, "month"))
 #'
 #' # Every 2 days, using an origin of day 0
 #' y <- duration_seconds(c(0, 86400, 86400 * 2, 86400 * 3))
@@ -521,8 +527,8 @@ duration_rounder <- function(x, precision, n, rounder, verb, ...) {
     x_precision <- precision_to_string(x_precision)
     message <- paste0(
       "Can't ", verb, " from ",
-      "'", x_precision, "' precision to ",
-      "'", precision, "' precision."
+      "a chronological precision (", x_precision, ") to ",
+      "a calendrical precision (", precision, ")."
     )
     abort(message)
   }

--- a/R/duration.R
+++ b/R/duration.R
@@ -312,11 +312,11 @@ as_duration.clock_duration <- function(x) {
 #' @export
 as_sys.clock_duration <- function(x) {
   names <- clock_rcrd_names(x)
-  precision <- duration_precision(x)
 
-  if (precision < PRECISION_DAY) {
-    abort("`x` must have at least 'day' precision to convert to a time point.")
-  }
+  # Promote to at least day precision for sys-time
+  x <- vec_cast(x, vec_ptype2(x, duration_days()))
+
+  precision <- duration_precision(x)
 
   new_sys_time_from_fields(x, precision, names)
 }

--- a/R/duration.R
+++ b/R/duration.R
@@ -228,7 +228,7 @@ vec_ptype2.clock_duration.clock_duration <- function(x, y, ...) {
       x = x,
       y = y,
       ...,
-      details = "Duration common type would not generate a named duration type."
+      details = "Can't combine calendrical durations with chronological durations."
     )
   }
 
@@ -248,15 +248,6 @@ vec_cast.clock_duration.clock_duration <- function(x, to, ...) {
     return(x)
   }
 
-  if (x_precision > to_precision) {
-    stop_incompatible_cast(
-      x = x,
-      to = to,
-      ...,
-      details = "Can't cast to a less precise precision."
-    )
-  }
-
   precision <- duration_precision_common_cpp(x_precision, to_precision)
 
   if (is.na(precision)) {
@@ -264,7 +255,16 @@ vec_cast.clock_duration.clock_duration <- function(x, to, ...) {
       x = x,
       to = to,
       ...,
-      details = "Duration cast cannot be done exactly."
+      details = "Can't cast between calendrical durations and chronological durations."
+    )
+  }
+
+  if (x_precision > to_precision) {
+    stop_incompatible_cast(
+      x = x,
+      to = to,
+      ...,
+      details = "Can't cast to a less precise precision."
     )
   }
 

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -806,11 +806,6 @@ seq.clock_time_point <- function(from,
                                  ...) {
   precision <- time_point_precision(from)
 
-  if (is_duration(by)) {
-    by_precision <- duration_precision(by)
-    validate_time_point_duration_op_precision(by_precision, arg = "by")
-  }
-
   seq_impl(
     from = from,
     to = to,
@@ -836,19 +831,4 @@ validate_time_point_precision_string <- function(precision) {
 
 is_valid_time_point_precision <- function(precision) {
   precision >= PRECISION_DAY
-}
-
-# Some operations combine a time point with a duration. These typically
-# work by extracting out the duration from the time point, and then calling
-# a duration specific function that works on two durations. Even though the
-# underlying duration function might allow things like
-# `duration<second> + duration<year>`, we don't want to allow
-# `time_point<second> + duration<year>`, as this just gives a confusing result.
-validate_time_point_duration_op_precision <- function(precision, arg = "precision") {
-  if (precision < PRECISION_WEEK) {
-    message <- paste0("`", arg, "` must be at least 'week' precision.")
-    abort(message)
-  }
-
-  precision
 }

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -227,8 +227,8 @@ arith_time_point_and_time_point <- function(op, x, y, ...) {
 arith_time_point_and_duration <- function(op, x, y, ...) {
   switch (
     op,
-    "+" = time_point_plus_duration(x, y, duration_precision(y), "y", names_common(x, y)),
-    "-" = time_point_minus_duration(x, y, duration_precision(y), "y", names_common(x, y)),
+    "+" = time_point_plus_duration(x, y, duration_precision(y), names_common(x, y)),
+    "-" = time_point_minus_duration(x, y, duration_precision(y), names_common(x, y)),
     stop_incompatible_op(op, x, y, ...)
   )
 }
@@ -236,7 +236,7 @@ arith_time_point_and_duration <- function(op, x, y, ...) {
 arith_duration_and_time_point <- function(op, x, y, ...) {
   switch (
     op,
-    "+" = time_point_plus_duration(y, x, duration_precision(x), "x", names_common(x, y)),
+    "+" = time_point_plus_duration(y, x, duration_precision(x), names_common(x, y)),
     "-" = stop_incompatible_op(op, x, y, details = "Can't subtract a time point from a duration.", ...),
     stop_incompatible_op(op, x, y, ...)
   )
@@ -247,8 +247,8 @@ arith_time_point_and_numeric <- function(op, x, y, ...) {
 
   switch (
     op,
-    "+" = time_point_plus_duration(x, y, precision, "y", names_common(x, y)),
-    "-" = time_point_minus_duration(x, y, precision, "y", names_common(x, y)),
+    "+" = time_point_plus_duration(x, y, precision, names_common(x, y)),
+    "-" = time_point_minus_duration(x, y, precision, names_common(x, y)),
     stop_incompatible_op(op, x, y, ...)
   )
 }
@@ -258,7 +258,7 @@ arith_numeric_and_time_point <- function(op, x, y, ...) {
 
   switch (
     op,
-    "+" = time_point_plus_duration(y, x, precision, "x", names_common(x, y)),
+    "+" = time_point_plus_duration(y, x, precision, names_common(x, y)),
     "-" = stop_incompatible_op(op, x, y, details = "Can't subtract a time point from a duration.", ...),
     stop_incompatible_op(op, x, y, ...)
   )
@@ -362,59 +362,59 @@ NULL
 #' @rdname time-point-arithmetic
 #' @export
 add_weeks.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_WEEK, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_WEEK, names_common(x, n))
 }
 
 #' @rdname time-point-arithmetic
 #' @export
 add_days.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_DAY, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_DAY, names_common(x, n))
 }
 
 #' @rdname time-point-arithmetic
 #' @export
 add_hours.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_HOUR, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_HOUR, names_common(x, n))
 }
 
 #' @rdname time-point-arithmetic
 #' @export
 add_minutes.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_MINUTE, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_MINUTE, names_common(x, n))
 }
 
 #' @rdname time-point-arithmetic
 #' @export
 add_seconds.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_SECOND, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_SECOND, names_common(x, n))
 }
 
 #' @rdname time-point-arithmetic
 #' @export
 add_milliseconds.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_MILLISECOND, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_MILLISECOND, names_common(x, n))
 }
 
 #' @rdname time-point-arithmetic
 #' @export
 add_microseconds.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_MICROSECOND, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_MICROSECOND, names_common(x, n))
 }
 
 #' @rdname time-point-arithmetic
 #' @export
 add_nanoseconds.clock_time_point <- function(x, n, ...) {
-  time_point_plus_duration(x, n, PRECISION_NANOSECOND, "n", names_common(x, n))
+  time_point_plus_duration(x, n, PRECISION_NANOSECOND, names_common(x, n))
 }
 
-time_point_plus_duration <- function(x, n, precision_n, n_arg, names) {
-  time_point_arith_duration(x, n, precision_n, n_arg, names, duration_plus)
+time_point_plus_duration <- function(x, n, precision_n, names) {
+  time_point_arith_duration(x, n, precision_n, names, duration_plus)
 }
-time_point_minus_duration <- function(x, n, precision_n, n_arg, names) {
-  time_point_arith_duration(x, n, precision_n, n_arg, names, duration_minus)
+time_point_minus_duration <- function(x, n, precision_n, names) {
+  time_point_arith_duration(x, n, precision_n, names, duration_minus)
 }
 
-time_point_arith_duration <- function(x, n, precision_n, n_arg, names, duration_fn) {
+time_point_arith_duration <- function(x, n, precision_n, names, duration_fn) {
   clock <- time_point_clock(x)
   x <- time_point_duration(x)
 

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -419,7 +419,6 @@ time_point_arith_duration <- function(x, n, precision_n, n_arg, names, duration_
   x <- time_point_duration(x)
 
   n <- duration_collect_n(n, precision_n)
-  validate_time_point_duration_op_precision(precision_n, n_arg)
 
   # Handles recycling and casting
   duration <- duration_fn(x = x, y = n, names = names)

--- a/man/duration-arithmetic.Rd
+++ b/man/duration-arithmetic.Rd
@@ -78,17 +78,11 @@ added together, and the precision of the result is determined as the
 \emph{more precise precision} of the two durations.
 }
 \details{
-Duration arithmetic is most useful when adding sub-daily or daily
-precisions together, or when adding monthly/quarterly/yearly precisions to
-other durations of similar precisions.
-
-Be \emph{extremely} careful when adding sub-daily or daily precisions to less
-precise precisions, such as monthly or yearly. Durations are defined in terms
-of a number of seconds, and calendrical months and years cannot be broken
-down like that, since they are irregular periods of time (there aren't always
-30 days in a month, or 365 days in a year). Read the Internal Representation
-section of the documentation for \link[=duration-helper]{duration helpers} to
-learn more about how durations are defined.
+You can add calendrical durations to other calendrical durations,
+and chronological durations to other chronological durations, but you can't
+add a chronological duration to a calendrical duration
+(such as adding days and months). For more information, see the
+documentation on the \link[=duration-helper]{duration helper} page.
 
 \code{x} and \code{n} are recycled against each other.
 }
@@ -105,6 +99,10 @@ add_days(x, 1)
 # precision of the two back, which is seconds
 y <- duration_days(1)
 add_seconds(y, 5)
+
+# But you can't add a chronological duration (days) and
+# a calendrical duration (months)
+try(add_months(y, 1))
 
 # You can add years to a duration of months, which adds
 # an additional 12 months / year

--- a/man/duration-helper.Rd
+++ b/man/duration-helper.Rd
@@ -47,7 +47,32 @@ A duration of the specified precision.
 }
 \description{
 These helpers construct durations of the specified precision. Durations
-represent units of time in a specified precision.
+represent units of time.
+
+Durations are separated into two categories:
+
+\strong{Calendrical}
+\itemize{
+\item year
+\item quarter
+\item month
+}
+
+\strong{Chronological}
+\itemize{
+\item week
+\item day
+\item hour
+\item minute
+\item second
+\item millisecond
+\item microsecond
+\item nanosecond
+}
+
+Calendrical durations are generally used when manipulating calendar types,
+like year-month-day. Chronological durations are generally used when
+working with time points, like sys-time or naive-time.
 }
 \section{Internal Representation}{
 
@@ -77,6 +102,13 @@ A duration of 1 month is defined as exactly 1/12 of a year.
 A duration of 1 quarter is defined as exactly 1/4 of a year.
 
 A duration of 1 week is defined as exactly 7 days.
+
+These conversions come into play when doing operations like adding or
+flooring durations. Generally, you add two calendrical durations together
+to get a new calendrical duration, rather than adding a calendrical and
+a chronological duration together. The one exception is \code{\link[=duration_cast]{duration_cast()}},
+which can cast durations to any other precision, with a potential loss of
+information.
 }
 
 \examples{

--- a/man/duration-rounding.Rd
+++ b/man/duration-rounding.Rd
@@ -41,6 +41,9 @@ A precision. One of:
 
 A positive integer specifying the multiple of \code{precision} to use.}
 }
+\value{
+\code{x} rounded to the \code{precision}.
+}
 \description{
 \itemize{
 \item \code{duration_floor()} rounds a duration down to a multiple of the specified
@@ -52,18 +55,21 @@ rounding up on ties.
 }
 }
 \details{
-Durations can be separated into two groups for rounding purposes. You can
-round within these groups, but not across these groups:
-\itemize{
-\item year, quarter, month
-\item week, day, hour, minute, second, millisecond, microsecond, nanosecond
-}
+You can floor calendrical durations to other calendrical durations, and
+chronological durations to other chronological durations, but you can't
+floor a chronological duration to a calendrical duration (such as flooring
+from day to month). For more information, see the documentation on the
+\link[=duration-helper]{duration helper} page.
 }
 \examples{
 x <- duration_seconds(c(86399, 86401))
 
 duration_floor(x, "day")
 duration_ceiling(x, "day")
+
+# Can't floor from a chronological duration (seconds)
+# to a calendrical duration (months)
+try(duration_floor(x, "month"))
 
 # Every 2 days, using an origin of day 0
 y <- duration_seconds(c(0, 86400, 86400 * 2, 86400 * 3))

--- a/man/duration-rounding.Rd
+++ b/man/duration-rounding.Rd
@@ -52,18 +52,12 @@ rounding up on ties.
 }
 }
 \details{
-Duration rounding is most useful when rounding from sub-daily precisions up
-to daily precision, or when rounding monthly/quarterly precisions up to
-yearly precision. These durations are defined intuitively relative to
-each other.
-
-Be \emph{extremely} careful when rounding sub-daily or daily precisions up to more
-granular precisions such as monthly or yearly. Durations are defined in terms
-of a number of seconds, and calendrical months and years cannot be broken
-down like that, since they are irregular periods of time (there aren't always
-30 days in a month, or 365 days in a year). Read the Internal Representation
-section of the documentation for \link[=duration-helper]{duration helpers} to
-learn more about how durations are defined.
+Durations can be separated into two groups for rounding purposes. You can
+round within these groups, but not across these groups:
+\itemize{
+\item year, quarter, month
+\item week, day, hour, minute, second, millisecond, microsecond, nanosecond
+}
 }
 \examples{
 x <- duration_seconds(c(86399, 86401))
@@ -83,4 +77,9 @@ duration_floor(y - origin, "day", n = 2) + origin
 half_day <- 86400 / 2
 half_day_durations <- duration_seconds(c(half_day - 1, half_day, half_day + 1))
 duration_round(half_day_durations, "day")
+
+# With larger units
+x <- duration_months(c(0, 15, 24))
+duration_floor(x, "year")
+duration_floor(x, "quarter")
 }

--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -848,18 +848,12 @@ duration_rounding_switch(cpp11::list_of<cpp11::integers>& fields,
   }
   case precision::week: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(dw, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(dw, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(dw, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(dw, n, type);
     default: clock_abort("Internal error: Invalid precision combination.");
     }
   }
   case precision::day: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(dd, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(dd, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(dd, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(dd, n, type);
     case precision::day: return duration_rounding_impl<duration::days>(dd, n, type);
     default: clock_abort("Internal error: Invalid precision combination.");
@@ -867,9 +861,6 @@ duration_rounding_switch(cpp11::list_of<cpp11::integers>& fields,
   }
   case precision::hour: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(dh, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(dh, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(dh, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(dh, n, type);
     case precision::day: return duration_rounding_impl<duration::days>(dh, n, type);
     case precision::hour: return duration_rounding_impl<duration::hours>(dh, n, type);
@@ -878,9 +869,6 @@ duration_rounding_switch(cpp11::list_of<cpp11::integers>& fields,
   }
   case precision::minute: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(dmin, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(dmin, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(dmin, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(dmin, n, type);
     case precision::day: return duration_rounding_impl<duration::days>(dmin, n, type);
     case precision::hour: return duration_rounding_impl<duration::hours>(dmin, n, type);
@@ -890,9 +878,6 @@ duration_rounding_switch(cpp11::list_of<cpp11::integers>& fields,
   }
   case precision::second: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(ds, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(ds, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(ds, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(ds, n, type);
     case precision::day: return duration_rounding_impl<duration::days>(ds, n, type);
     case precision::hour: return duration_rounding_impl<duration::hours>(ds, n, type);
@@ -903,9 +888,6 @@ duration_rounding_switch(cpp11::list_of<cpp11::integers>& fields,
   }
   case precision::millisecond: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(dmilli, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(dmilli, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(dmilli, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(dmilli, n, type);
     case precision::day: return duration_rounding_impl<duration::days>(dmilli, n, type);
     case precision::hour: return duration_rounding_impl<duration::hours>(dmilli, n, type);
@@ -917,9 +899,6 @@ duration_rounding_switch(cpp11::list_of<cpp11::integers>& fields,
   }
   case precision::microsecond: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(dmicro, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(dmicro, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(dmicro, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(dmicro, n, type);
     case precision::day: return duration_rounding_impl<duration::days>(dmicro, n, type);
     case precision::hour: return duration_rounding_impl<duration::hours>(dmicro, n, type);
@@ -932,9 +911,6 @@ duration_rounding_switch(cpp11::list_of<cpp11::integers>& fields,
   }
   case precision::nanosecond: {
     switch (precision_to_val) {
-    case precision::year: return duration_rounding_impl<duration::years>(dnano, n, type);
-    case precision::quarter: return duration_rounding_impl<duration::quarters>(dnano, n, type);
-    case precision::month: return duration_rounding_impl<duration::months>(dnano, n, type);
     case precision::week: return duration_rounding_impl<duration::weeks>(dnano, n, type);
     case precision::day: return duration_rounding_impl<duration::days>(dnano, n, type);
     case precision::hour: return duration_rounding_impl<duration::hours>(dnano, n, type);

--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -572,7 +572,10 @@ duration_scalar_divide_cpp(cpp11::list_of<cpp11::integers> x,
  * Restricts normal result returned by `std::common_type()` to only allow
  * combinations of:
  *
+ * Calendrical durations:
  * - year, quarter, month
+ *
+ * Chronological durations:
  * - week, day, hour, minute, second, microsecond, millisecond, nanosecond
  *
  * These two groups consist of durations that are intuitively defined relative
@@ -586,21 +589,22 @@ std::pair<enum precision, bool>
 duration_common_precision_impl() {
   using CT = typename std::common_type<Duration1, Duration2>::type;
 
-  const bool duration1_granular =
+  const bool duration1_calendrical =
     std::is_same<Duration1, date::years>::value ||
     std::is_same<Duration1, quarterly::quarters>::value ||
     std::is_same<Duration1, date::months>::value;
 
-  const bool duration2_granular =
+  const bool duration2_calendrical =
     std::is_same<Duration2, date::years>::value ||
     std::is_same<Duration2, quarterly::quarters>::value ||
     std::is_same<Duration2, date::months>::value;
 
-  // Duration combinations that cross the month/week boundary are invalid
-  if (duration1_granular && !duration2_granular) {
+  // Duration combinations that cross the
+  // calendrical/chronological boundary are invalid
+  if (duration1_calendrical && !duration2_calendrical) {
     return std::make_pair(precision::year, false);
   }
-  if (!duration1_granular && duration2_granular) {
+  if (!duration1_calendrical && duration2_calendrical) {
     return std::make_pair(precision::year, false);
   }
 

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -1,3 +1,11 @@
+# can't round across common precision boundary
+
+    Can't ceiling from 'week' precision to 'month' precision.
+
+---
+
+    Can't floor from 'second' precision to 'year' precision.
+
 # seq() validates from
 
     `from` must have size 1, not size 2.

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -174,3 +174,13 @@
     Can't combine `x` <duration<second>> and `y` <duration<year>>.
     Can't combine calendrical durations with chronological durations.
 
+# can't convert calendrical duration to time point
+
+    Can't combine <duration<year>> and <duration<day>>.
+    Can't combine calendrical durations with chronological durations.
+
+---
+
+    Can't combine <duration<year>> and <duration<day>>.
+    Can't combine calendrical durations with chronological durations.
+

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -71,7 +71,7 @@
 ---
 
     Can't convert `to` <duration<day>> to match type of `from` <duration<year>>.
-    Can't cast to a less precise precision.
+    Can't cast between calendrical durations and chronological durations.
 
 ---
 
@@ -99,13 +99,18 @@
 
 # `by` must be castable to the type of `from`
 
-    Can't convert `by` <duration<day>> to <duration<year>>.
+    Can't convert `by` <duration<month>> to <duration<year>>.
     Can't cast to a less precise precision.
 
 ---
 
+    Can't convert `by` <duration<day>> to <duration<year>>.
+    Can't cast between calendrical durations and chronological durations.
+
+---
+
     Can't convert `by` <duration<year>> to <duration<day>>.
-    Duration cast cannot be done exactly.
+    Can't cast between calendrical durations and chronological durations.
 
 # seq() validates `length.out`
 
@@ -152,7 +157,7 @@
 # `to` is always cast to `from`
 
     Can't convert `to` <duration<year>> to match type of `from` <duration<day>>.
-    Duration cast cannot be done exactly.
+    Can't cast between calendrical durations and chronological durations.
 
 ---
 

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -164,3 +164,13 @@
     Can't convert `to` <duration<month>> to match type of `from` <duration<year>>.
     Can't cast to a less precise precision.
 
+# can't add chronological and calendrical durations
+
+    Can't combine `x` <duration<year>> and `y` <duration<second>>.
+    Can't combine calendrical durations with chronological durations.
+
+---
+
+    Can't combine `x` <duration<second>> and `y` <duration<year>>.
+    Can't combine calendrical durations with chronological durations.
+

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -1,10 +1,10 @@
 # can't round across common precision boundary
 
-    Can't ceiling from 'week' precision to 'month' precision.
+    Can't ceiling from a chronological precision (week) to a calendrical precision (month).
 
 ---
 
-    Can't floor from 'second' precision to 'year' precision.
+    Can't floor from a chronological precision (second) to a calendrical precision (year).
 
 # seq() validates from
 

--- a/tests/testthat/_snaps/time-point.md
+++ b/tests/testthat/_snaps/time-point.md
@@ -27,9 +27,10 @@
 
     Can't convert `origin` <datetime<America/New_York>> to <time_point<naive><day>>.
 
-# `by` must be at least 'week' precision (#120)
+# can't mix chronological time points and calendrical durations
 
-    `by` must be at least 'week' precision.
+    Can't convert `by` <duration<year>> to <duration<second>>.
+    Can't cast between calendrical durations and chronological durations.
 
 # can't mix clocks in seq()
 

--- a/tests/testthat/_snaps/time-point.md
+++ b/tests/testthat/_snaps/time-point.md
@@ -42,5 +42,6 @@
 
 # duration to add to a time-point must have at least week precision (#120)
 
-    `y` must be at least 'week' precision.
+    Can't combine `x` <duration<second>> and `y` <duration<year>>.
+    Can't combine calendrical durations with chronological durations.
 

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -253,3 +253,16 @@ test_that("can't add chronological and calendrical durations", {
   expect_snapshot_error(add_seconds(duration_years(1), 1))
   expect_snapshot_error(add_years(duration_seconds(1), 1))
 })
+
+# ------------------------------------------------------------------------------
+# as_sys() / as_naive()
+
+test_that("can convert week precision duration to time point", {
+  expect_identical(as_sys(duration_weeks(c(0, 1))), sys_days(c(0, 7)))
+  expect_identical(as_naive(duration_weeks(c(0, 1))), naive_days(c(0, 7)))
+})
+
+test_that("can't convert calendrical duration to time point", {
+  expect_snapshot_error(as_sys(duration_years(0)))
+  expect_snapshot_error(as_naive(duration_years(0)))
+})

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -245,3 +245,11 @@ test_that("special test to ensure we never lose precision (i.e. by trying to con
     duration_nanoseconds(0) + duration_cast(duration_years(c(0, 5, 10)), "nanosecond")
   )
 })
+
+# ------------------------------------------------------------------------------
+# add_*()
+
+test_that("can't add chronological and calendrical durations", {
+  expect_snapshot_error(add_seconds(duration_years(1), 1))
+  expect_snapshot_error(add_years(duration_seconds(1), 1))
+})

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -87,6 +87,11 @@ test_that("can't round to more precise precision", {
   expect_error(duration_floor(duration_seconds(1), "millisecond"), "more precise")
 })
 
+test_that("can't round across common precision boundary", {
+  expect_snapshot_error(duration_ceiling(duration_weeks(), "month"))
+  expect_snapshot_error(duration_floor(duration_seconds(), "year"))
+})
+
 test_that("input is validated", {
   expect_error(duration_floor(1, "year"), "must be a duration object")
   expect_error(duration_floor(duration_seconds(1), "foo"), "not recognized")

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -140,6 +140,7 @@ test_that("seq() validates `by`", {
 })
 
 test_that("`by` must be castable to the type of `from`", {
+  expect_snapshot_error(seq(duration_years(0), to = duration_years(1), by = duration_months(1)))
   expect_snapshot_error(seq(duration_years(0), to = duration_years(1), by = duration_days(1)))
   expect_snapshot_error(seq(duration_days(0), to = duration_days(1), by = duration_years(1)))
 })

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -1,4 +1,44 @@
 # ------------------------------------------------------------------------------
+# duration_precision_common_cpp()
+
+test_that("correctly computes common duration precision", {
+  granular <- c(
+    PRECISION_YEAR,
+    PRECISION_QUARTER,
+    PRECISION_MONTH
+  )
+
+  precise <- c(
+    PRECISION_WEEK,
+    PRECISION_DAY,
+    PRECISION_HOUR,
+    PRECISION_MINUTE,
+    PRECISION_SECOND,
+    PRECISION_MILLISECOND,
+    PRECISION_MICROSECOND,
+    PRECISION_NANOSECOND
+  )
+
+  for (p1 in granular) {
+    for (p2 in granular) {
+      expect_identical(duration_precision_common_cpp(p1, p2), max(p1, p2))
+    }
+  }
+
+  for (p1 in precise) {
+    for (p2 in precise) {
+      expect_identical(duration_precision_common_cpp(p1, p2), max(p1, p2))
+    }
+  }
+
+  for (p1 in granular) {
+    for (p2 in precise) {
+      expect_identical(duration_precision_common_cpp(p1, p2), NA_integer_)
+    }
+  }
+})
+
+# ------------------------------------------------------------------------------
 # duration_floor() / _ceiling() / _round()
 
 test_that("floor rounds down", {
@@ -195,7 +235,7 @@ test_that("`to` is always cast to `from`", {
 
 test_that("special test to ensure we never lose precision (i.e. by trying to convert to double)", {
   expect_identical(
-    seq(duration_nanoseconds(0), duration_years(10), length.out = 3),
-    duration_nanoseconds(0) + duration_years(c(0, 5, 10))
+    seq(duration_nanoseconds(0), duration_cast(duration_years(10), "nanosecond"), length.out = 3),
+    duration_nanoseconds(0) + duration_cast(duration_years(c(0, 5, 10)), "nanosecond")
   )
 })

--- a/tests/testthat/test-time-point.R
+++ b/tests/testthat/test-time-point.R
@@ -131,12 +131,7 @@ test_that("`by` can be a duration", {
   )
 })
 
-test_that("`by` must be at least 'week' precision (#120)", {
-  expect_identical(
-    seq(naive_seconds(0), by = duration_weeks(1), length.out = 2),
-    naive_seconds(0) + duration_weeks(c(0, 1))
-  )
-
+test_that("can't mix chronological time points and calendrical durations", {
   expect_snapshot_error(seq(naive_seconds(0), by = duration_years(1), length.out = 2))
 })
 


### PR DESCRIPTION
Closes #122 

Calendrical - year, quarter, month

Chronological - day, hour, minute, second, millisecond, microsecond, nanosecond

This allows for a much clearer picture of how durations interact with calendars and time points.

We lose the ability to do `duration<year> + duration<second>`, but that isn't a huge deal because it is normally confusing. If you really want this, you can do `duration_cast(duration<year>, "second") + duration<second>`.

`duration_cast()` is now the only function that can convert across the calendrical/chronological border.