### PR TITLE
Update embedded date library

### DIFF
--- a/inst/include/date/date.h
+++ b/inst/include/date/date.h
@@ -45,9 +45,7 @@
 #include <cctype>
 #include <chrono>
 #include <climits>
-#if !(__cplusplus >= 201402)
-#  include <cmath>
-#endif
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -6187,9 +6185,16 @@ long double
 read_long_double(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned M = 10)
 {
     unsigned count = 0;
+    unsigned fcount = 0;
+    unsigned long long i = 0;
+    unsigned long long f = 0;
+    bool parsing_fraction = false;
+#if ONLY_C_LOCALE
+    typename Traits::int_type decimal_point = '.';
+#else
     auto decimal_point = Traits::to_int_type(
         std::use_facet<std::numpunct<CharT>>(is.getloc()).decimal_point());
-    std::string buf;
+#endif
     while (true)
     {
         auto ic = is.peek();
@@ -6197,18 +6202,25 @@ read_long_double(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned
             break;
         if (Traits::eq_int_type(ic, decimal_point))
         {
-            buf += '.';
             decimal_point = Traits::eof();
-            is.get();
+            parsing_fraction = true;
         }
         else
         {
             auto c = static_cast<char>(Traits::to_char_type(ic));
             if (!('0' <= c && c <= '9'))
                 break;
-            buf += c;
-            (void)is.get();
+            if (!parsing_fraction)
+            {
+                i = 10*i + static_cast<unsigned>(c - '0');
+            }
+            else
+            {
+                f = 10*f + static_cast<unsigned>(c - '0');
+                ++fcount;
+            }
         }
+        (void)is.get();
         if (++count == M)
             break;
     }
@@ -6217,7 +6229,7 @@ read_long_double(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned
         is.setstate(std::ios::failbit);
         return 0;
     }
-    return std::stold(buf);
+    return i + f/std::pow(10.L, fcount);
 }
 
 struct rs
@@ -6984,7 +6996,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
 #else
                         auto nm = detail::ampm_names();
                         auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
-                        tp = i;
+                        tp = static_cast<decltype(tp)>(i);
 #endif
                         checked_set(p, tp, not_a_ampm, is);
                     }

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2661,7 +2661,7 @@ get_version()
         in >> version;
         return version;
     }
-    return version;
+    return "unknown";
 }
 
 static
@@ -2772,6 +2772,7 @@ init_tzdb()
                 strcmp(d->d_name, "iso3166.tab")  == 0      ||
                 strcmp(d->d_name, "right")        == 0      ||
                 strcmp(d->d_name, "+VERSION")     == 0      ||
+                strcmp(d->d_name, "version")      == 0      ||
                 strcmp(d->d_name, "zone.tab")     == 0      ||
                 strcmp(d->d_name, "zone1970.tab") == 0      ||
                 strcmp(d->d_name, "tzdata.zi")    == 0      ||

--- a/tools/update
+++ b/tools/update
@@ -9,4 +9,4 @@ Updating `clock` dependencies
 3. Run `update-date-library.R` to update the headers and `tz.cpp` in `src/`.
 
 4. Go back through `tz.cpp` and comment out all uses to `std::cerr()`, which
-   R CMD Check doesn't like.
+   R CMD Check doesn't like. And ensure that any custom additions are kept.

--- a/tools/update-date-library.R
+++ b/tools/update-date-library.R
@@ -7,6 +7,8 @@ library(glue)
 # The `tz.cpp` file that is downloaded into `src/tz.cpp` will need to be updated
 # to pass R CMD Check. All calls to `std::cerr` will have to be commented out.
 #
+# There are also a few additions to `date.h` that will need to be added back in.
+#
 # The rest of the date API is downloaded into `inst/include/date/`
 # and is header only.
 
@@ -37,14 +39,17 @@ dir_pkg_inst_include_date <- here("inst", "include", "date")
 
 dir_copy(dir_date_include_date, dir_pkg_inst_include_date, overwrite = TRUE)
 
+# Remember to add the custom additions back in!
+
 # ------------------------------------------------------------------------------
 # Update `src/tz.cpp`
-# Important - this file will need to be tweaked!
 
 file_date_src_tz <- path(dir_date, "src", "tz.cpp")
 file_pkg_src_tz <- path("src", "tz.cpp")
 
 file_copy(file_date_src_tz, file_pkg_src_tz, overwrite = TRUE)
+
+# Remember to add the custom additions back in!
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #146 

One of the date.h changes updated `read_long_double()` (used for reading seconds / fractional seconds). It no longer uses `strtold()`, and instead parses this in a custom way that is a good bit faster. I've incorporated these into our custom `read_seconds()`.

A simple test showed reading 1e6 second precision strings in 550ms, when it used to take 700ms. The same amount of nanosecond precision strings now read in 800ms when it used to take 1000ms.