### PR TITLE
Add "Supported By Posit" badge to clock website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,6 +5,7 @@ template:
   package: tidytemplate
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="clock.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
@@ -12,9 +13,7 @@ development:
 
 reference:
 - title: High Level API
-  desc: This section contains the high level API for R's native date and
-    date-time types (Date, POSIXct, and POSIXlt). For most clock users, these
-    are the only functions you'll need.
+  desc: This section contains the high level API for R's native date and date-time types (Date, POSIXct, and POSIXlt). For most clock users, these are the only functions you'll need.
 - subtitle: Construction
   contents:
   - date_build
@@ -55,8 +54,7 @@ reference:
   - as_date_time
 
 - title: Calendars
-  desc: This section contains the overarching `calendar_*()` API that applies to
-    all calendars. See the subsections for details about a specific calendar.
+  desc: This section contains the overarching `calendar_*()` API that applies to all calendars. See the subsections for details about a specific calendar.
   contents:
   - calendar_group
   - calendar_count_between
@@ -230,8 +228,7 @@ reference:
   - vec_arith.clock_year_month_day
 
 - title: Generics and methods
-  desc: This section contains documentation about generics and methods that is
-    already exposed elsewhere on this reference page.
+  desc: This section contains documentation about generics and methods that is already exposed elsewhere on this reference page.
   contents:
   - add_years
   - get_year


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the clock website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of clock website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/clock-1200.png)

At 992px browser width:

![Screenshot of clock website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/clock-992.png)

At 991px browser width:

![Screenshot of clock website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/clock-991.png)

